### PR TITLE
Start centrally handling "events"

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="./tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         forceCoversAnnotation="false"
+         mapTestClassNameToCoveredClassName="false"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false">
+  <testsuites>
+    <testsuite name="Tests">
+      <directory suffix=".php">./tests/Tests</directory>
+    </testsuite>
+  </testsuites>
+
+  <php>
+    <ini name="memory_limit" value="-1"/>
+  </php>
+
+  <filter>
+    <blacklist>
+      <directory>./vendor</directory>
+      <directory>./tests/</directory>
+    </blacklist>
+    <whitelist processUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">./library</directory>
+    </whitelist>
+  </filter>
+
+</phpunit>


### PR DESCRIPTION
1. Give a downstream implementer a funnel to "catch" all events as they flow through the system. With this, I could easily add an event system (such as Symfony EventDispatcher/Zend Event Manager) to be quickly snapped in by extending `AbstractCommand`
-- Long term could have pluggable systems for either
2. Allows `phpunit` to be run from source root as `./vendor/bin/phpunit`
3. Ensure that metrics/circuitbreakers are updated *before* events are "called" -- just incase the event solution goes off the rails :)

@lcf I'd love to get this running under TravisCI or an alternative, interested? 
I would also be very interested in undertaking a bit of legwork to decouple some of the dependencies (Zend Config/DI), which will allow easier integration in other projects -- especially when the dependencies themselves are updating much faster than before. For example, if we flattened out the configuration before creating a command, we could plug various configuration backends in at the factory level, and leave the command itself more generic. Next, I'd love to refit more of the requestCache/requestLog pieces to be optional, as well as driven by actual events instead of coded inline. What do you think?